### PR TITLE
feat!: modernize to Polly v8 resilience and .NET 8/10 (v2.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [net6.0, net7.0]
+        target: [net8.0, net10.0]
     runs-on: self-hosted
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
+            10.0.x
 
       - name: Restore test dependencies
         run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [net6.0, net7.0]
+        target: [net8.0, net10.0]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
+            10.0.x
 
       - name: Restore test dependencies
         run: dotnet restore
@@ -40,7 +40,7 @@ jobs:
         run: dotnet pack -c Release -p:PackageVersion=${{  github.ref_name }}
 
       - name: Upload nuget package artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Nuget package
           path: "**/*.nupkg"

--- a/Configuration/KamiOptions.cs
+++ b/Configuration/KamiOptions.cs
@@ -6,6 +6,29 @@ public class KamiOptions
 
     public string? Token { get; set; }
     public string BaseAddress { get; set; } = "https://api.notablepdf.com/";
+
+    /// <summary>
+    /// Total time allowed for a single Kami API call (including retries) before it is cancelled.
+    /// Document uploads and view-session creation can be slow, so this defaults generously.
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 100;
+
+    /// <summary>
+    /// Number of times a transient failure is retried (exponential backoff with jitter) before the call fails.
+    /// </summary>
+    public int RetryCount { get; set; } = 3;
+
+    /// <summary>
+    /// Seconds to wait between polls while an <c>ExportFile</c> document export is still pending.
+    /// </summary>
+    public int ExportPollIntervalSeconds { get; set; } = 2;
+
+    /// <summary>
+    /// Maximum number of times <c>ExportFile</c> polls for a pending export before giving up,
+    /// so a stuck export cannot loop forever.
+    /// </summary>
+    public int ExportMaxPollAttempts { get; set; } = 60;
+
     public List<string> AllowedExtensions { get; set; } = new List<string>()
     {
         "doc",

--- a/Kami.Sdk.csproj
+++ b/Kami.Sdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -25,12 +25,12 @@
   <ItemGroup>
 		<PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.5"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.10"/>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10"/>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.10"/>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="kami.png" Pack="true" PackagePath="\" />

--- a/KamiClient.cs
+++ b/KamiClient.cs
@@ -10,20 +10,26 @@ namespace OnCourse.Kami;
 
 public interface IKamiClient
 {
-    Task<KamiUploadResult> UploadFile(byte[] file, string contentType, string fileName);
-    Task<KamiDeleteResult> DeleteFile(string documentIdentifier);
-    Task<KamiCreateViewSessionResult> CreateViewSession(string documentIdentifier, string userName, string userId, DateTime? expiresAt = null, KamiViewerOptions? viewerOptions = null, bool editable = true);
-    Task<KamiDocumentExportResult> ExportFile(string documentIdentifier, string exportType = "inline");
+    Task<KamiUploadResult> UploadFile(byte[] file, string contentType, string fileName, CancellationToken cancellationToken = default);
+    Task<KamiDeleteResult> DeleteFile(string documentIdentifier, CancellationToken cancellationToken = default);
+    Task<KamiCreateViewSessionResult> CreateViewSession(string documentIdentifier, string userName, string userId, DateTime? expiresAt = null, KamiViewerOptions? viewerOptions = null, bool editable = true, CancellationToken cancellationToken = default);
+    Task<KamiDocumentExportResult> ExportFile(string documentIdentifier, string exportType = "inline", CancellationToken cancellationToken = default);
 }
 
 public class KamiClient : IKamiClient
 {
+    // Name of the unconfigured factory client used to download exported files from Kami's storage host.
+    // It must NOT be the typed client, whose default Authorization header would leak to a foreign host.
+    private const string ExportDownloadClientName = "KamiExportDownload";
+
     private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly KamiOptions _kamiOptions;
 
-    public KamiClient(HttpClient httpClient, IOptions<KamiOptions> kamiOptions)
+    public KamiClient(HttpClient httpClient, IHttpClientFactory httpClientFactory, IOptions<KamiOptions> kamiOptions)
     {
         _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
         _kamiOptions = kamiOptions.Value;
     }
 
@@ -40,7 +46,7 @@ public class KamiClient : IKamiClient
         return _kamiOptions.AllowedExtensions.Contains(ext.ToLower());
     }
 
-    public async Task<KamiUploadResult> UploadFile(byte[] file, string contentType, string fileName)
+    public async Task<KamiUploadResult> UploadFile(byte[] file, string contentType, string fileName, CancellationToken cancellationToken = default)
     {
         const string boundary = "-----BOUNDARY";
 
@@ -63,7 +69,7 @@ public class KamiClient : IKamiClient
         documentContent.Headers.TryAddWithoutValidation("Content-Type", contentType);
         multiPartContent.Add(documentContent);
 
-        var response = await _httpClient.PostAsync("upload/embed/documents", multiPartContent).ConfigureAwait(false);
+        using var response = await _httpClient.PostAsync("upload/embed/documents", multiPartContent, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -76,7 +82,7 @@ public class KamiClient : IKamiClient
 
         try
         {
-            var data = response.Content.ReadAsStringAsync().Result;
+            var data = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<KamiUploadResult>(data, JsonSerialization.GetDefaultSerializerSettings()) ?? new KamiUploadResult
             {
                 Success = false,
@@ -93,9 +99,9 @@ public class KamiClient : IKamiClient
         }
     }
 
-    public async Task<KamiDeleteResult> DeleteFile(string documentIdentifier)
+    public async Task<KamiDeleteResult> DeleteFile(string documentIdentifier, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync("embed/documents/" + documentIdentifier).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync("embed/documents/" + documentIdentifier, cancellationToken).ConfigureAwait(false);
         return new KamiDeleteResult
         {
             Success = response.IsSuccessStatusCode,
@@ -103,9 +109,9 @@ public class KamiClient : IKamiClient
         };
     }
 
-    public async Task<KamiCreateViewSessionResult> CreateViewSession(string documentIdentifier, string userName, string userId, DateTime? expiresAt = null, KamiViewerOptions? viewerOptions = null, bool editable = true)
+    public async Task<KamiCreateViewSessionResult> CreateViewSession(string documentIdentifier, string userName, string userId, DateTime? expiresAt = null, KamiViewerOptions? viewerOptions = null, bool editable = true, CancellationToken cancellationToken = default)
     {
-        var expirationDate = (expiresAt ?? DateTime.Now.AddYears(1)).ToString(CultureInfo.InvariantCulture);
+        var expirationDate = (expiresAt ?? DateTime.UtcNow.AddYears(1)).ToString(CultureInfo.InvariantCulture);
         var requestJson = JsonConvert.SerializeObject(new
         {
             DocumentIdentifier = documentIdentifier,
@@ -119,8 +125,8 @@ public class KamiClient : IKamiClient
             Editable = editable
         }, JsonSerialization.GetDefaultSerializerSettings());
 
-        var content = new StringContent(requestJson, Encoding.Default, "application/json");
-        var response = await _httpClient.PostAsync("embed/sessions", content).ConfigureAwait(false);
+        using var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync("embed/sessions", content, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -133,7 +139,7 @@ public class KamiClient : IKamiClient
 
         try
         {
-            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var data = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var sessionResult = JsonConvert.DeserializeObject<KamiCreateViewSessionResult>(data, JsonSerialization.GetDefaultSerializerSettings());
 
             if (sessionResult == null)
@@ -158,19 +164,34 @@ public class KamiClient : IKamiClient
         }
     }
 
-    public async Task<KamiDocumentExportResult> ExportFile(string documentIdentifier, string exportType = "inline")
+    public async Task<KamiDocumentExportResult> ExportFile(string documentIdentifier, string exportType = "inline", CancellationToken cancellationToken = default)
     {
-        var result = await CreateDocumentExport(documentIdentifier, exportType).ConfigureAwait(false);
+        var result = await CreateDocumentExport(documentIdentifier, exportType, cancellationToken).ConfigureAwait(false);
 
+        // Poll until the export finishes, with a delay between attempts and a hard cap so a stuck
+        // export can't spin a tight, unbounded loop hammering the Kami API.
+        var attempts = 0;
         while (result?.Status == "pending")
         {
-            result = await GetDocumentExport(result.Id).ConfigureAwait(false);
+            if (++attempts > _kamiOptions.ExportMaxPollAttempts)
+            {
+                return new KamiDocumentExportResult
+                {
+                    Status = "error",
+                    ErrorType = "Timed out waiting for the document export to complete"
+                };
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(_kamiOptions.ExportPollIntervalSeconds), cancellationToken).ConfigureAwait(false);
+            result = await GetDocumentExport(result.Id, cancellationToken).ConfigureAwait(false);
         }
 
         if (result?.Status == "done")
         {
-            using var client = new HttpClient();
-            result.FileBytes = await client.GetByteArrayAsync(result.FileUrl).ConfigureAwait(false);
+            // The exported file lives on a different (storage) host, so use a plain factory client rather
+            // than the typed client whose Kami Authorization header would otherwise be sent to that host.
+            var downloadClient = _httpClientFactory.CreateClient(ExportDownloadClientName);
+            result.FileBytes = await downloadClient.GetByteArrayAsync(result.FileUrl, cancellationToken).ConfigureAwait(false);
         }
 
         return result ?? new KamiDocumentExportResult
@@ -180,7 +201,7 @@ public class KamiClient : IKamiClient
         };
     }
 
-    private async Task<KamiDocumentExportResult> CreateDocumentExport(string documentIdentifier, string exportType)
+    private async Task<KamiDocumentExportResult> CreateDocumentExport(string documentIdentifier, string exportType, CancellationToken cancellationToken)
     {
         var requestJson = JsonConvert.SerializeObject(new
         {
@@ -188,8 +209,8 @@ public class KamiClient : IKamiClient
             ExportType = exportType
         }, JsonSerialization.GetDefaultSerializerSettings());
 
-        using var content = new StringContent(requestJson, Encoding.Default, "application/json");
-        using var response = await _httpClient.PostAsync("embed/exports", content).ConfigureAwait(false);
+        using var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync("embed/exports", content, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             return new KamiDocumentExportResult
@@ -201,7 +222,7 @@ public class KamiClient : IKamiClient
 
         try
         {
-            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var data = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<KamiDocumentExportResult>(data, JsonSerialization.GetDefaultSerializerSettings()) ?? new KamiDocumentExportResult
             {
                 Status = "error",
@@ -218,9 +239,9 @@ public class KamiClient : IKamiClient
         }
     }
 
-    private async Task<KamiDocumentExportResult> GetDocumentExport(string exportId)
+    private async Task<KamiDocumentExportResult> GetDocumentExport(string exportId, CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync("embed/exports/" + exportId).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync("embed/exports/" + exportId, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             return new KamiDocumentExportResult
@@ -232,7 +253,7 @@ public class KamiClient : IKamiClient
 
         try
         {
-            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var data = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<KamiDocumentExportResult>(data, JsonSerialization.GetDefaultSerializerSettings()) ?? new KamiDocumentExportResult
             {
                 Status = "error",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Kami API library helps to generate requests for the following services:
 
 ## ⭐ Installation
 
-This project is a class library built for compatibility all the back to .NET Standard 2.0.
+This project is a class library targeting .NET 8 and .NET 10.
 
 To install the OnCourse.Kami NuGet package, run the following command via the dotnet CLI
 
@@ -56,18 +56,24 @@ var app = builder.Build();
 
 ### Fault Handling / Resilience
 
-By default, the client will be configured to retry a call up to three times with increasing waits between (1s, 5s, 10s). If after the third call the service still returns an error then the call will be considered failed. You can override this policy during the UseKami method by passing in a policy as the second parameter. It is recommended to use [Polly](https://github.com/App-vNext/Polly), a 3rd-party library, that has a lot of options for creating policies
+The client is configured with a [Polly v8](https://github.com/App-vNext/Polly) resilience pipeline (via `Microsoft.Extensions.Http.Resilience`) that retries transient failures with exponential backoff and jitter, then caps the whole call with a timeout. Both are configured from the `Kami` settings section — by default, **3 retries** and a **100 second timeout** (see [Configuration](#configuration)). A timeout surfaces to callers as a `TaskCanceledException`.
+
+For advanced scenarios you can customize the pipeline directly by passing a configuration action as the second parameter:
 
 ```csharp
+using Polly;
 
-builder.Services.AddKamiClient(builder.Configuration, (p => p.WaitAndRetryAsync(new[]
+builder.Services.AddKamiClient(builder.Configuration, pipeline =>
 {
-    TimeSpan.FromSeconds(1),
-    TimeSpan.FromSeconds(5),
-    TimeSpan.FromSeconds(10)
-}));
-
+    pipeline.AddConcurrencyLimiter(10);
+});
 ```
+
+> **Note:** if you host with .NET Aspire `ServiceDefaults` (or otherwise call `AddStandardResilienceHandler` via `ConfigureHttpClientDefaults`), that global handler is *also* applied to the Kami client and will layer a second pipeline on top. To let this SDK own Kami's resilience, opt the client out of the global handler:
+>
+> ```csharp
+> builder.Services.AddHttpClient(nameof(IKamiClient)).RemoveAllResilienceHandlers();
+> ```
 
 ### Configuration
 
@@ -78,6 +84,10 @@ Additional configuration can be done in the appSettings.config file within the "
   "Kami": {
     "Token": "Token #####################",
     "BaseAddress": "https://api.notablepdf.com/",
+    "TimeoutSeconds": 100,
+    "RetryCount": 3,
+    "ExportPollIntervalSeconds": 2,
+    "ExportMaxPollAttempts": 60,
     "AllowedExtensions": [
       "doc",
       "docx",

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
+using Ardalis.GuardClauses;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
+using OnCourse.Kami;
 using OnCourse.Kami.Configuration;
 using Polly;
-using OnCourse.Kami;
-using Ardalis.GuardClauses;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -13,27 +15,42 @@ public static class ServiceCollectionExtensions
         return services.AddKamiClient(configuration, null);
     }
 
-    public static IServiceCollection AddKamiClient(this IServiceCollection services, IConfiguration configuration, Func<PolicyBuilder<HttpResponseMessage>, IAsyncPolicy<HttpResponseMessage>>? errorPolicy = null)
+    /// <param name="configureResilience">
+    /// Optional hook to customize the Polly v8 resilience pipeline (retry + timeout) applied to the Kami client.
+    /// Leave null to use the retry/timeout values from <see cref="KamiOptions"/>.
+    /// </param>
+    public static IServiceCollection AddKamiClient(this IServiceCollection services, IConfiguration configuration, Action<ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null)
     {
         services.Configure<KamiOptions>(configuration.GetSection(KamiOptions.SectionName));
 
         var address = configuration["Kami:BaseAddress"];
         var token = configuration["Kami:Token"];
 
-        Guard.Against.NullOrEmpty(address, "Kami:BassAddress", "Missing Kami BaseAddress in settings.");
-        Guard.Against.NullOrEmpty(token, "Kami:Token", "Missing Kami Token in settings.");
+        Guard.Against.NullOrEmpty(address, nameof(address), "Missing Kami BaseAddress in settings.");
+        Guard.Against.NullOrEmpty(token, nameof(token), "Missing Kami Token in settings.");
 
         services.AddHttpClient<IKamiClient, KamiClient>(client =>
         {
             client.BaseAddress = new Uri(address);
             client.DefaultRequestHeaders.TryAddWithoutValidation("authorization", token);
         })
-        .AddTransientHttpErrorPolicy(errorPolicy ?? (p => p.WaitAndRetryAsync(new[]
+        .AddResilienceHandler("kami", (pipeline, context) =>
         {
-            TimeSpan.FromSeconds(1),
-            TimeSpan.FromSeconds(5),
-            TimeSpan.FromSeconds(10)
-        })));
+            var options = context.ServiceProvider.GetRequiredService<IOptions<KamiOptions>>().Value;
+
+            // Retry transient failures (5xx, 408, network errors) with exponential backoff, then cap the
+            // whole call with a timeout. A timeout surfaces to callers as a TaskCanceledException.
+            pipeline
+                .AddRetry(new HttpRetryStrategyOptions
+                {
+                    MaxRetryAttempts = options.RetryCount,
+                    BackoffType = DelayBackoffType.Exponential,
+                    UseJitter = true,
+                })
+                .AddTimeout(TimeSpan.FromSeconds(options.TimeoutSeconds));
+
+            configureResilience?.Invoke(pipeline);
+        });
 
         return services;
     }

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -29,25 +29,29 @@ public static class ServiceCollectionExtensions
         Guard.Against.NullOrEmpty(address, nameof(address), "Missing Kami BaseAddress in settings.");
         Guard.Against.NullOrEmpty(token, nameof(token), "Missing Kami Token in settings.");
 
-        services.AddHttpClient<IKamiClient, KamiClient>(client =>
+        services.AddHttpClient<IKamiClient, KamiClient>((serviceProvider, client) =>
         {
+            var options = serviceProvider.GetRequiredService<IOptions<KamiOptions>>().Value;
             client.BaseAddress = new Uri(address);
             client.DefaultRequestHeaders.TryAddWithoutValidation("authorization", token);
+
+            // Cap the whole call (including retries) with HttpClient.Timeout rather than a Polly timeout
+            // strategy. A timeout then surfaces to callers as a plain TaskCanceledException instead of a
+            // Polly TimeoutRejectedException, and it still applies if a host opts the client out of
+            // resilience handlers (e.g. RemoveAllResilienceHandlers under .NET Aspire defaults).
+            client.Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds);
         })
         .AddResilienceHandler("kami", (pipeline, context) =>
         {
             var options = context.ServiceProvider.GetRequiredService<IOptions<KamiOptions>>().Value;
 
-            // Retry transient failures (5xx, 408, network errors) with exponential backoff, then cap the
-            // whole call with a timeout. A timeout surfaces to callers as a TaskCanceledException.
-            pipeline
-                .AddRetry(new HttpRetryStrategyOptions
-                {
-                    MaxRetryAttempts = options.RetryCount,
-                    BackoffType = DelayBackoffType.Exponential,
-                    UseJitter = true,
-                })
-                .AddTimeout(TimeSpan.FromSeconds(options.TimeoutSeconds));
+            // Retry transient failures (5xx, 408, network errors) with exponential backoff and jitter.
+            pipeline.AddRetry(new HttpRetryStrategyOptions
+            {
+                MaxRetryAttempts = options.RetryCount,
+                BackoffType = DelayBackoffType.Exponential,
+                UseJitter = true,
+            });
 
             configureResilience?.Invoke(pipeline);
         });


### PR DESCRIPTION
## Summary

Modernizes the SDK off the legacy Polly v7 stack and EOL runtimes, makes resilience configurable, and fixes several correctness bugs found along the way.

**This is a breaking change — intended to release as `OnCourse.Kami` 2.0.0.**

### Motivation
Investigating a production `Polly.Timeout.TimeoutRejectedException` (30s) on the Kami `CreateViewSession` call surfaced that this SDK pins **`Microsoft.Extensions.Http.Polly` (Polly v7)** and targets **net6.0/net7.0 (both EOL)**. The v7 dependency collides with the Polly v8 that modern Aspire `AddStandardResilienceHandler` consumers pull in (forcing `extern alias`/reflection workarounds downstream). This brings the SDK to Polly v8 and current runtimes so consumers stop inheriting the legacy dependency.

## Changes

### Resilience (Polly v7 → v8)
- Drop `Microsoft.Extensions.Http.Polly`; use `Microsoft.Extensions.Http.Resilience` (v8) with a retry (exponential backoff + jitter) **+ timeout** pipeline.
- Retry count and timeout are now configurable via `KamiOptions` (`RetryCount`, `TimeoutSeconds`).
- `AddKamiClient` override param: Polly-v7 `Func<PolicyBuilder…>` → v8 `Action<ResiliencePipelineBuilder<HttpResponseMessage>>`.
- Bump `Microsoft.Extensions.*` 7.0.x → 9.0.10; TFMs `net6.0;net7.0` → `net8.0;net10.0`.

### Correctness fixes in `KamiClient`
- `UploadFile`: `await` the response body instead of blocking on `.Result` (sync-over-async / threadpool starvation).
- `ExportFile`: download via an `IHttpClientFactory` client — avoids socket exhaustion from `new HttpClient()` **and** stops leaking the Kami `Authorization` header to the storage host.
- `ExportFile`: bound the previously-unbounded poll loop with a delay, max attempts, and cancellation.
- `Encoding.Default` → `Encoding.UTF8`; `DateTime.Now` → `DateTime.UtcNow`.
- Thread `CancellationToken` through all `IKamiClient` methods.

### Docs / CI
- Rewrite README resilience section, fix the false ".NET Standard 2.0" claim, document new options.
- CI/release matrix → `net8.0/net10.0`; bump deprecated `checkout`/`setup-dotnet`/`upload-artifact` to v4.

## Breaking changes for consumers
- TFMs are now net8.0/net10.0.
- `AddKamiClient`'s optional 2nd arg is now a Polly v8 pipeline action.
- `IKamiClient` methods gained a trailing optional `CancellationToken` (breaks custom `IKamiClient` implementations; positional/named callers unaffected).

## Verification
- Builds clean on both net8.0 and net10.0 (0 warnings).
- `dotnet pack` produces `OnCourse.Kami.2.0.0.nupkg`; verified the nuspec has both TFM groups, no `Microsoft.Extensions.Http.Polly`, and `Microsoft.Extensions.Http.Resilience` 9.9.0.

## Out of scope (flagged for a follow-up)
The `release.yml` `publish` job has no checkout step before `dotnet pack` — it relies on the self-hosted runner reusing the build workspace. Worth fixing separately.