### PR TITLE
chore: bump dependencies to latest stable

### DIFF
--- a/Kami.Sdk.csproj
+++ b/Kami.Sdk.csproj
@@ -23,14 +23,14 @@
     <PackageIcon>kami.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
-		<PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.10"/>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10"/>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.10"/>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0"/>
+		<PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="kami.png" Pack="true" PackagePath="\" />


### PR DESCRIPTION
## Summary

Brings all NuGet dependencies up to the latest stable versions. The `Microsoft.Extensions.*` packages were a major version behind the `net10.0` target framework, so this aligns them to the matching `10.x` band (still supports `net8.0`).

## Changes

| Package | Old | New |
|---|---|---|
| Microsoft.Extensions.Options | 9.0.10 | 10.0.8 |
| Microsoft.Extensions.DependencyInjection | 9.0.10 | 10.0.8 |
| Microsoft.Extensions.Configuration | 9.0.10 | 10.0.8 |
| Microsoft.Extensions.Http | 9.0.10 | 10.0.8 |
| Microsoft.Extensions.Options.ConfigurationExtensions | 9.0.10 | 10.0.8 |
| Microsoft.Extensions.Http.Resilience | 9.9.0 | 10.6.0 |
| Newtonsoft.Json | 13.0.3 | 13.0.4 |
| Ardalis.GuardClauses | 4.0.1 | 5.0.0 |

## Notes

- **Ardalis.GuardClauses 5.0.0** is a major bump. Verified the two existing `Guard.Against.NullOrEmpty(...)` call sites in `ServiceCollectionExtensions.cs` compile clean — 5.0.0 kept the existing overloads.
- Builds clean on **both** `net8.0` and `net10.0` with zero warnings/errors.

## Follow-ups (not in this PR)

- Consider Central Package Management (`Directory.Packages.props`) to keep the `Microsoft.Extensions.*` versions from drifting apart.
- Consider migrating Newtonsoft.Json -> built-in `System.Text.Json`.